### PR TITLE
config: add file picker name filter for .mkv extension

### DIFF
--- a/contents/ui/config.qml
+++ b/contents/ui/config.qml
@@ -57,7 +57,7 @@ ColumnLayout {
     FileDialog {
         id: fileDialog
         title: "Pick a video file"
-        nameFilters: [ "Video files (*.mp4 *.mpg *.ogg *.mov *.webm *.flv *.matroska *.avi *.m3u)", "All files (*)" ]
+        nameFilters: [ "Video files (*.mp4 *.mpg *.ogg *.mov *.webm *.flv *.mkv *.matroska *.avi *.m3u)", "All files (*)" ]
         onAccepted: {
             cfg_Video = fileDialog.fileUrls[0]
             cfg_Folder = fileDialog.folder


### PR DESCRIPTION
Matroska video files typically have an extension of .mkv, so add
that in addition to .matroska.